### PR TITLE
Remove stray ipdb breakpoint from checkpoint loader

### DIFF
--- a/robometer/utils/setup_utils.py
+++ b/robometer/utils/setup_utils.py
@@ -265,9 +265,6 @@ def _load_checkpoint_weights_from_safetensors(
     if not progress_head_loaded:
         logger.error("Progress head weights did not change after loading checkpoint!")
         logger.error("This indicates the checkpoint weights were not loaded correctly.")
-        import ipdb
-
-        ipdb.set_trace()  # Breakpoint if progress_head didn't load
 
     # Verify adapter weights loaded correctly (if PEFT is enabled)
     adapter_loaded_correctly = True


### PR DESCRIPTION
## Summary
- remove an accidental ipdb breakpoint from checkpoint loading
- keep the existing error logging when progress-head weights fail to load

## Why
An interactive debugger breakpoint should not be reachable in normal training or smoke runs, especially on remote jobs where it kills the process with bdb.BdbQuit instead of surfacing a clean failure.
