### PR TITLE
fix sampling and padding bugs and some small env issues

### DIFF
--- a/eval_commands/policy_ranking.sh
+++ b/eval_commands/policy_ranking.sh
@@ -17,6 +17,7 @@ uv run python robometer/evals/run_baseline_eval.py \
     custom_eval.policy_ranking=[rbm-1m-ood] \
     custom_eval.use_frame_steps=false \
     custom_eval.num_examples_per_quality_pr=1000 \
+    custom_eval.pad_frames=false \
     max_frames=64 \
     model_config.batch_size=1
 
@@ -29,6 +30,7 @@ uv run python robometer/evals/run_baseline_eval.py \
     custom_eval.policy_ranking=[rbm-1m-ood] \
     custom_eval.use_frame_steps=false \
     custom_eval.num_examples_per_quality_pr=1000 \
+    custom_eval.pad_frames=false \
     max_frames=64 \
     model_config.batch_size=1
 

--- a/eval_commands/reward_alignment.sh
+++ b/eval_commands/reward_alignment.sh
@@ -18,6 +18,7 @@ uv run python robometer/evals/run_baseline_eval.py \
     custom_eval.reward_alignment=[rbm-1m-id,rbm-1m-ood] \
     custom_eval.use_frame_steps=false \
     custom_eval.reward_alignment_max_trajectories=30 \
+    custom_eval.pad_frames=false \
     max_frames=64 \
     model_config.batch_size=1
 
@@ -30,6 +31,7 @@ uv run python robometer/evals/run_baseline_eval.py \
     custom_eval.reward_alignment=[rbm-1m-id,rbm-1m-ood] \
     custom_eval.use_frame_steps=false \
     custom_eval.reward_alignment_max_trajectories=30 \
+    custom_eval.pad_frames=false \
     max_frames=64 \
     model_config.batch_size=1
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ dependencies = [
     "torchvision",
     "moviepy",
     "wandb[media]",
-    "torchcodec",
+    "torchcodec>=0.6,<0.8",
     "decord>=0.6.0",
     "unsloth>=2025.10",
     "gymnasium>=1.2.2",
@@ -159,6 +159,7 @@ flash-attn = { FLASH_ATTENTION_SKIP_CUDA_BUILD = "TRUE" }
 [tool.uv.sources]
 torch = { index = "pytorch-cu128", marker = "sys_platform == 'linux' or sys_platform == 'win32'" }
 torchvision = { index = "pytorch-cu128", marker = "sys_platform == 'linux' or sys_platform == 'win32'" }
+torchcodec = { index = "pytorch-cu128", marker = "sys_platform == 'linux' or sys_platform == 'win32'" }
 
 [[tool.uv.index]]
 name = "pytorch-cu128"

--- a/requirements-robodopamine.txt
+++ b/requirements-robodopamine.txt
@@ -40,7 +40,7 @@ seaborn
 bitsandbytes
 moviepy
 wandb[media]
-torchcodec
+torchcodec>=0.6,<0.8
 decord>=0.6.0
 unsloth>=2025.10
 gymnasium>=1.2.2

--- a/robometer/data/dataset_types.py
+++ b/robometer/data/dataset_types.py
@@ -39,6 +39,7 @@ class Trajectory(BaseModel):
         None  # Mask for partial_success: 1.0 for last frame if partial_success < 1.0, otherwise all 1.0s
     )
     metadata: Optional[Dict[str, Any]] = None
+    original_sampled_index: Optional[int] = None
     data_gen_strategy: Optional[str] = None
 
     model_config = ConfigDict(arbitrary_types_allowed=True)

--- a/robometer/data/samplers/base.py
+++ b/robometer/data/samplers/base.py
@@ -704,6 +704,10 @@ class RBMBaseSampler:
                 target_progress = [target_progress[idx] for idx in frame_indices_subsample]
             indices = [indices[idx] for idx in frame_indices_subsample] if isinstance(indices, list) else indices
 
+            original_sampled_index = -1
+
+        else:
+            original_sampled_index = indices[-1] # record the original last sampled time index before potential padding
         # Pad if needed
         if target_progress and pad_frames:
             if self.config.load_embeddings:
@@ -777,6 +781,7 @@ class RBMBaseSampler:
                 "partial_success": partial_success,
                 "predict_last_frame_mask": predict_last_frame_mask,
                 "metadata": metadata,
+                "original_sampled_index": original_sampled_index,
             },
         )
         return trajectory

--- a/robometer/evals/baselines/rbd_inference.py
+++ b/robometer/evals/baselines/rbd_inference.py
@@ -451,7 +451,7 @@ class GRMInference:
 
         self.model = LLM(
             model=model_path,
-            gpu_memory_utilization=0.8,
+            gpu_memory_utilization=0.9,
             max_model_len=8192,
             limit_mm_per_prompt={"image": max_image_num},
             enable_prefix_caching=True,

--- a/robometer/evals/baselines/rbd_inference.py
+++ b/robometer/evals/baselines/rbd_inference.py
@@ -27,8 +27,9 @@ from transformers import AutoProcessor
 from moviepy.video.io.ImageSequenceClip import ImageSequenceClip
 
 # Global Environment Settings
-os.environ["LOCAL_RANK"] = "0"
-os.environ["CUDA_VISIBLE_DEVICES"] = "0"
+os.environ.setdefault("LOCAL_RANK", "0")
+if "CUDA_VISIBLE_DEVICES" not in os.environ:
+    os.environ["CUDA_VISIBLE_DEVICES"] = "0"
 
 
 # -----------------------------
@@ -450,7 +451,7 @@ class GRMInference:
 
         self.model = LLM(
             model=model_path,
-            gpu_memory_utilization=0.9,
+            gpu_memory_utilization=0.8,
             max_model_len=8192,
             limit_mm_per_prompt={"image": max_image_num},
             enable_prefix_caching=True,

--- a/robometer/evals/compile_results.py
+++ b/robometer/evals/compile_results.py
@@ -281,6 +281,7 @@ def run_reward_alignment_eval_per_trajectory(
         raw_targets = []
         traj_pred_logits = []  # For discrete mode: collect full logits
         traj_target_bins = []  # For discrete mode: collect bin indices
+        original_sampled_indices = []
 
         if not use_frame_steps:
             # Whole trajectory mode: one result with full progress prediction
@@ -292,6 +293,7 @@ def run_reward_alignment_eval_per_trajectory(
             for timestep, r in enumerate(results_for_trajectory):
                 raw_preds.append(r["progress_pred"])
                 raw_targets.append(r["target_progress"])
+                original_sampled_indices.append(r.get("original_sampled_index"))
 
         # Step 2: Convert all progress predictions and targets to continuous (if discrete mode)
         # Store logits/bins for loss computation before conversion
@@ -360,10 +362,15 @@ def run_reward_alignment_eval_per_trajectory(
                 traj_targets = tgt_array[-1:]
         else:
             # Frame steps mode
-            for timestep, (pred_array, tgt_array) in enumerate(zip(traj_preds_continuous, traj_targets_continuous)):
+            for timestep, (pred_array, tgt_array, original_sampled_index) in enumerate(zip(traj_preds_continuous, traj_targets_continuous, original_sampled_indices)):
                 if last_frame_only:
                     pred_val = pred_array[-1]
                     tgt_val = tgt_array[-1]
+                elif original_sampled_index is not None:
+                    pred_idx = min(int(original_sampled_index), len(pred_array) - 1)
+                    tgt_idx = min(int(original_sampled_index), len(tgt_array) - 1)
+                    pred_val = pred_array[pred_idx]
+                    tgt_val = tgt_array[tgt_idx]
                 else:
                     indx = min(timestep, len(pred_array) - 1)
                     pred_val = pred_array[indx]


### PR DESCRIPTION
# Pull Request Description

I would like to thank all the authors for their excellent work and for open-sourcing this project to the community!

This pull request fixes several bugs in the current implementation (see below).

---

## 1. Sample index in reward alignment metric computation

### What went wrong

When **`use_frame_steps=true`** (default setting of RoboMeter and RoboReward), multiple positions are sampled evenly from the full video to compute metrics. The previous implementation used the `enumerate` index as the retrieval index when aggregating predictions and targets (see the loop starting at [this line](https://github.com/robometer/robometer/blob/main/robometer/evals/compile_results.py#L363C13-L363C50), where **`timestep`** is the loop position, not the **actual subsampled frame index** in the original video). That results in the sampled indices being fixed to **`0, 1, 2, …`** (i.e. `range(0, custom_eval.subsample_n_frames)`, e.g. **`0 … 4`** when `subsample_n_frames=5`) for every video, instead of the **actual subsampled frame indices** in the original video (e.g. evenly spaced timesteps along the clip).

### What this PR does

I added **`original_sampled_index`** to record the sampled index in the original video. It is populated consistently (including after subsampling / padding), used in **`compile_results`** when aggregating metrics, and the `enumerate`-based path is kept only as a fallback when no valid index is available—so alignment follows the real sampling, not the loop position.

### Performance comparison (VOC average Pearson · policy ranking τ) based on my reproduction


| Metric (split)                      | ROBOMETER w/ RoboReward Training Data (from paper) | ROBOMETER (w/ RBM-1M) (from paper) | reimplementation before this fix | new implementation |
| ----------------------------------- | -------------------------------------------------- | ---------------------------------- | -------------------------------- | ------------------ |
| **VOC r** (RBM-EVAL-ID)             | **0.842**                                          | **0.921**                          | **0.841**                        | **0.860**          |
| **VOC r** (RBM-EVAL-OOD)            | **0.927**                                          | **0.948**                          | **0.927**                        | **0.886**          |
| **policy ranking τ** (RBM-EVAL-OOD) | **0.552**                                          | **0.655**                          | **0.649**                        | **0.649**          |


While reproducing the released code, I noticed that **before this fix**, VOC numbers line up more closely with the paper’s **“w/ RoboReward Training Data”** column than with the other reported columns. Could the authors help clarify whether this is expected, or whether some eval/config details on my side may still be misaligned with the paper?

---

## 2. Robo Dopamine implementation

### What went wrong

For **reward alignment** evaluation, the current behavior **includes padded frames** in the metric computation.

### What this PR does

To exclude padding, set `custom_eval.pad_frames=false` in the run script (If I understand correctly, the original Robo Dopamine setup did not use padding, and whether use padding will not influence the inference result, but it can change calculated metrics when padded repetitive frames are included in the metric aggregation).

---

## 3. Minor environment/requirements updates

I found that some dependency versions released after March 21 can introduce minor incompatibilities. This PR changes the requirements slightly so that packages do not conflict with each other.

---

## 4. vLLM GPU selection at startup (for Robo-Dopamine)

The previous startup path could overwrite externally provided GPU-related environment variables (e.g., `CUDA_VISIBLE_DEVICES` / `LOCAL_RANK`) with hardcoded defaults.

This PR changes the initialization logic to respect pre-set environment variables and only apply defaults when they are missing. This makes vLLM startup GPU assignment configurable from the launch environment (for example, shell scripts or scheduler settings), instead of being forced to a fixed device.

---

Thanks again for the solid work—looking forward to your feedback on this PR. :)