### PR TITLE
Unify parameter dtype after load to fix unsloth inference crash

### DIFF
--- a/robometer/utils/save.py
+++ b/robometer/utils/save.py
@@ -920,6 +920,20 @@ def load_model_from_hf(
         exp_config.model, str(resolved_path), peft_config=peft_config
     )
     reward_model = reward_model.to(device)
+
+    # Unsloth loads models with mixed precision (e.g. float32 token embeddings and the
+    # vision patch_embed alongside bf16 linears) for training stability. That mismatch
+    # breaks inference: float32 activations flow into bf16 weights and the forward
+    # raises "expected scalar type BFloat16 but found Float" (and an analogous error in
+    # the language-model attention). Since this loader returns an eval-only model, cast
+    # every floating-point parameter to the configured dtype so the forward is
+    # dtype-consistent. Integer parameters and buffers (e.g. rotary inv_freq, which RoPE
+    # recomputes in float32) are intentionally left untouched.
+    target_dtype = getattr(torch, exp_config.model.torch_dtype, torch.bfloat16)
+    for param in reward_model.parameters():
+        if param.is_floating_point() and param.dtype != target_dtype:
+            param.data = param.data.to(target_dtype)
+
     reward_model.eval()
 
     return exp_config, tokenizer, processor, reward_model


### PR DESCRIPTION
First, thanks to the authors for open-sourcing this work!

## Problem

Running inference on a released checkpoint (e.g. `robometer/Robometer-4B`) crashes out of the box. With the shipped example:

```bash
python scripts/example_inference_local.py \
  --model-path robometer/Robometer-4B \
  --video scripts/example_videos/berkeley_rpt_stack_cup.mp4 \
  --task "stack the cup"
```

the forward raises:

```
RuntimeError: expected scalar type BFloat16 but found Float
```

in the Qwen3-VL vision blocks (`norm1`), and once that is worked around, an analogous error in the language-model attention:

```
RuntimeError: expected mat1 and mat2 to have the same dtype, but got: float != c10::BFloat16
```

I reproduced this across **transformers 4.57.x and 5.x**, so it is not a transformers-version regression.

## Root cause

The released checkpoint config sets `use_unsloth=true`. Unsloth loads the model with **mixed precision** for training stability — the token embeddings and the vision `patch_embed` come up in **float32** while the linear layers are **bf16**. That is fine for training, but at inference time float32 activations flow into bf16 weights and the forward fails.

## Fix

`load_model_from_hf` returns an eval-only model (it already calls `.eval()`), so this casts every floating-point **parameter** to the configured `torch_dtype` after load, making the forward dtype-consistent. Integer parameters and **buffers** (e.g. rotary `inv_freq`, which RoPE recomputes in float32) are intentionally left untouched.

```python
target_dtype = getattr(torch, exp_config.model.torch_dtype, torch.bfloat16)
for param in reward_model.parameters():
    if param.is_floating_point() and param.dtype != target_dtype:
        param.data = param.data.to(target_dtype)
```

Placing it in `load_model_from_hf` (rather than in `example_inference_local.py`) fixes every inference/eval entry point that loads through this function, and leaves the training path untouched.

## Verification

After the change, the same command runs to completion and produces sensible per-frame progress (monotonically increasing across a successful "stack the cup" clip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)