### PR TITLE
Add ArmnetBench (SO-101 eval+teleop) dataset to the training mix

### DIFF
--- a/dataset_upload/dataset_guides/ArmnetBench.md
+++ b/dataset_upload/dataset_guides/ArmnetBench.md
@@ -10,9 +10,6 @@ The HF repo is versioned (`_v01`); the logical `data_source` stays `armnetbench`
 versions so it remains a single source in the training mix.
 
 - HF dataset: `https://huggingface.co/datasets/villekuosmanen/armnetbench_robometer_v01`
-- Conversion tooling (in the alpha-robotics monorepo, not in this repo):
-  `remoterobo/armnetbench/convert_eval_to_robometer.py` (LeRobot v3.0 → RBM) and
-  `remoterobo/armnetbench/compute_lang_vectors.py` (all-MiniLM-L6-v2 `lang_vector`).
 
 ## Overview
 
@@ -22,7 +19,6 @@ versions so it remains a single source in the training mix.
 - `quality_label`: teleop → `successful`; policy rollouts → `successful` / `failure` /
   `suboptimal` (from the per-episode eval labels). No numeric `partial_success` — text
   classes only, so failures/suboptimals pair against same-task teleop successes.
-- Task instruction is overridden per `task_id` (not the source dataset's task text).
 - Successful/suboptimal episodes are trimmed to a labelled completion time, removing trailing
   idle frames so the positional progress target ramps to actual task completion.
 - Videos: H.264, shortest edge 240 — matching the other RBM datasets.

--- a/dataset_upload/dataset_guides/ArmnetBench.md
+++ b/dataset_upload/dataset_guides/ArmnetBench.md
@@ -1,0 +1,54 @@
+# ArmnetBench Evaluation Dataset Guide
+
+ArmnetBench is an SO-101 robot evaluation + teleoperation dataset in Robometer (RBM) format,
+produced from LeRobot v3.0 eval rollouts. It is **already converted** (one video per episode
+per camera, with the unified `BASE_FEATURES` metadata), so there is **no `dataset_upload`
+loader** — it is consumed directly by `preprocess_datasets.py` / training like any other RBM
+Hub dataset.
+
+The HF repo is versioned (`_v01`); the logical `data_source` stays `armnetbench` across
+versions so it remains a single source in the training mix.
+
+- HF dataset: `https://huggingface.co/datasets/villekuosmanen/armnetbench_robometer_v01`
+- Conversion tooling (in the alpha-robotics monorepo, not in this repo):
+  `remoterobo/armnetbench/convert_eval_to_robometer.py` (LeRobot v3.0 → RBM) and
+  `remoterobo/armnetbench/compute_lang_vectors.py` (all-MiniLM-L6-v2 `lang_vector`).
+
+## Overview
+
+- `data_source = "armnetbench"` — a single source in the training mix (stable across repo versions).
+- Subsets (HF configs) per embodiment: `so101` today (`bimanual_so101` will be added later).
+- One trajectory per episode **per camera** (front / top / wrist), `is_robot=true`.
+- `quality_label`: teleop → `successful`; policy rollouts → `successful` / `failure` /
+  `suboptimal` (from the per-episode eval labels). No numeric `partial_success` — text
+  classes only, so failures/suboptimals pair against same-task teleop successes.
+- Task instruction is overridden per `task_id` (not the source dataset's task text).
+- Successful/suboptimal episodes are trimmed to a labelled completion time, removing trailing
+  idle frames so the positional progress target ramps to actual task completion.
+- Videos: H.264, shortest edge 240 — matching the other RBM datasets.
+
+## Registration in this repo
+
+- `robometer/configs/preprocess.yaml`: `villekuosmanen/armnetbench_robometer_v01` + subset `so101`.
+- `robometer/data/dataset_category.py`: `DATASET_MAP["armnetbench_v01"]` alias; `armnetbench`
+  added to `DATA_SOURCE_CATEGORY["suboptimal_fail"]` (it has failures/suboptimals with same-task
+  successes). Note the alias is versioned (`armnetbench_v01`) while the `data_source` is `armnetbench`.
+- `robometer/data/dataset_success_cutoff.txt`: `armnetbench,0.95`.
+- `robometer/data/datasets/name_mapping.py`: `villekuosmanen_armnetbench_robometer_v01_so101 →
+  armnetbench_so101`.
+
+## Usage
+
+```bash
+export ROBOMETER_DATASET_PATH=/path/to/datasets
+huggingface-cli download villekuosmanen/armnetbench_robometer_v01 --repo-type dataset \
+  --local-dir $ROBOMETER_DATASET_PATH/armnetbench_robometer_v01
+
+uv run python -m robometer.data.scripts.preprocess_datasets \
+  --config robometer/configs/preprocess.yaml \
+  --cache_dir=$ROBOMETER_PROCESSED_DATASETS_PATH
+```
+
+Then train with `data.train_datasets=[armnetbench_v01]` (alias), or reference
+`villekuosmanen_armnetbench_robometer_v01_so101` directly in an aggregate. It is intentionally
+**not** added to the `rbm-1m-id` default mix — opt it in (and choose weighting) once evaluated.

--- a/robometer/configs/preprocess.yaml
+++ b/robometer/configs/preprocess.yaml
@@ -20,6 +20,7 @@ train_datasets:
   - "jesbu1/racer_rfm"
   - "jesbu1/roboreward_rfm"
   - "jesbu1/roboreward_rfm_high_res"
+  - "villekuosmanen/armnetbench_robometer_v01"
 
 train_subsets:
   - ["metaworld_train"]
@@ -43,6 +44,7 @@ train_subsets:
   - ["racer_train"]
   - ["roboreward_train"]
   - ["roboreward_train"]
+  - ["so101"]
 
 eval_datasets:
   - "abraranwar/libero_rfm"

--- a/robometer/data/dataset_category.py
+++ b/robometer/data/dataset_category.py
@@ -53,6 +53,7 @@ ALL_DATASOURCES = [
     "usc_koch_human_robot_paired_robot",
     "hand_paired_human",
     "hand_paired_robot",
+    "armnetbench",
 ]
 
 DATASET_CATEGORY = {
@@ -87,6 +88,10 @@ DATASET_CATEGORY = {
 }
 
 DATASET_MAP = {
+    "armnetbench_v01": {
+        "train": ["villekuosmanen_armnetbench_robometer_v01_so101"],
+        "eval": ["villekuosmanen_armnetbench_robometer_v01_so101"],
+    },
     "others": {
         "train": [
             "jesbu1_molmoact_rfm_molmoact_dataset_household",
@@ -471,6 +476,7 @@ DATA_SOURCE_CATEGORY = {
         "racer_train",
         "racer_val",
         "roboarena_eval_debug_nowrist",
+        "armnetbench",
     ],
     "franka": [
         "oxe_droid",

--- a/robometer/data/dataset_success_cutoff.txt
+++ b/robometer/data/dataset_success_cutoff.txt
@@ -63,3 +63,4 @@ humanoid_everyday_rfm,0.80
 motif_rfm,0.95
 roboarena_eval_debug_nowrist,0.90
 roboarena,0.90
+armnetbench,0.95

--- a/robometer/data/datasets/name_mapping.py
+++ b/robometer/data/datasets/name_mapping.py
@@ -93,4 +93,6 @@ DS_SHORT_NAME_MAPPING = {
     "abraranwar_usc_koch_rewind_rfm_usc_koch_rewind": "usc_koch_rewind",
     # RoboFAC
     "aliangdw_robofac_rbm_robofac": "robofac",
+    # ArmnetBench (SO-101 eval + teleop)
+    "villekuosmanen_armnetbench_robometer_v01_so101": "armnetbench_so101",
 }


### PR DESCRIPTION
Registers villekuosmanen/armnetbench_robometer_v01 (RBM format, subset `so101`):
- preprocess.yaml: add repo + `so101` subset
- dataset_category.py: `armnetbench_v01` DATASET_MAP alias + `armnetbench` suboptimal_fail category
- dataset_success_cutoff.txt: armnetbench,0.95
- name_mapping.py: armnetbench_so101 short name
- dataset_guides/ArmnetBench.md: provenance + usage (already-converted, no loader)