### PR TITLE
Fix DIFFERENT_TASK_INSTRUCTION overwriting swapped instruction 

### DIFF
--- a/robometer/data/samplers/progress.py
+++ b/robometer/data/samplers/progress.py
@@ -151,12 +151,14 @@ class ProgressSampler(RBMBaseSampler):
             return None
 
         # Handle special cases
-        if strategy_used in [DataGenStrat.DIFFERENT_TASK, DataGenStrat.DIFFERENT_TASK_INSTRUCTION]:
-            # We need to use the original task embeddings instead of the different task embeddings
+        if strategy_used == DataGenStrat.DIFFERENT_TASK:
+            # Restore original task embeddings (video is from a different task)
             if self.config.load_embeddings and traj.get("embeddings_path"):
                 progress_traj.text_embedding = load_embeddings_from_path(traj["embeddings_path"])["text_embedding"]
             progress_traj.lang_vector = traj["lang_vector"]
             progress_traj.task = traj["task"]
+
+        if strategy_used in [DataGenStrat.DIFFERENT_TASK, DataGenStrat.DIFFERENT_TASK_INSTRUCTION]:
             progress_traj.target_progress = [0.0] * len(progress_traj.target_progress)
             if self.config.progress_loss_type.lower() == "discrete":
                 progress_traj.target_progress = convert_continuous_to_discrete_bins(


### PR DESCRIPTION
## Summary
  - Fixes #36
  - The embedding/lang_vector/task restore block in `_create_progress_sample` was applied to both `DIFFERENT_TASK` and `DIFFERENT_TASK_INSTRUCTION`, but should only apply to `DIFFERENT_TASK`
  - For `DIFFERENT_TASK_INSTRUCTION`, the swapped instruction should be preserved (video stays the same, only the instruction changes)
  - Both strategies still correctly set `target_progress=0` and `success_label=0`

  ## Details
  `DIFFERENT_TASK`: grabs a video from a *different task*, restores original instruction → model learns that mismatched video gets 0 progress

  `DIFFERENT_TASK_INSTRUCTION`: keeps the *same video*, swaps in a different instruction → model learns that mismatched instruction gets 0 progress

  The bug caused `DIFFERENT_TASK_INSTRUCTION` to overwrite the swapped instruction back to the original, resulting in correctly-matched samples mislabeled as 0 progress.